### PR TITLE
Update N_UTL_CheckIfValidFile.C

### DIFF
--- a/src/UtilityPKG/N_UTL_CheckIfValidFile.C
+++ b/src/UtilityPKG/N_UTL_CheckIfValidFile.C
@@ -24,6 +24,7 @@
 
 #include <fstream>
 #include <string>
+#include <stdio.h>
 
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>


### PR DESCRIPTION
Experienced following build error. Seems to not have found the `fileno` function that exists in `<stdio.h`
```
[ 48%] Building CXX object src/CMakeFiles/XyceLib.dir/ErrorHandlingPKG/N_ERH_Message.C.o
/cygdrive/c/SPB_Data/xyce_dev/Xyce/src/UtilityPKG/N_UTL_CheckIfValidFile.C: In function ‘bool Xyce::Util::checkIfValidFile(std::string)’:
/cygdrive/c/SPB_Data/xyce_dev/Xyce/src/UtilityPKG/N_UTL_CheckIfValidFile.C:70:22: error: ‘fileno’ was not declared in this scope; did you mean ‘fileInfo’?
   70 |     fstatret = fstat(fileno(fp), &fileInfo);
      |                      ^~~~~~
      |                      fileInfo
[ 48%] Building CXX object src/CMakeFiles/XyceLib.dir/ErrorHandlingPKG/N_ERH_Messenger.C.o
make[2]: *** [src/CMakeFiles/XyceLib.dir/build.make:3390: src/CMakeFiles/XyceLib.dir/UtilityPKG/N_UTL_CheckIfValidFile.C.o] Error 1
```

Revelant Build parameters:
```shell
if $DEBUG
then
XYCE_CXX_FLAGS="$XYCE_CXX_FLAGS -g"
XYCE_C_FLAGS="$XYCE_C_FLAGS -g"
XYCE_BUILD_TYPE="Debug"
# sed -i '84,88s/^#//' $XYCE_DEV_DIR/Xyce/src/Xyce_config.h.cmake # enable verbose
# sed -i '91,117s/^#//' $XYCE_DEV_DIR/Xyce/src/Xyce_config.h.cmake # enable debug
# modify build files to enable debug support
sed -i '54,58s/FALSE/TRUE/' $XYCE_DEV_DIR/Xyce/cmake/feature_modes.cmake # enable verbose
sed -i '61,87s/FALSE/TRUE/' $XYCE_DEV_DIR/Xyce/cmake/feature_modes.cmake # enable debug

fi

cd $XYCE_BUILD_DIR
if $PARALLEL_BUILD 
then
    XYCE_INSTALL_LOCATION="$XYCE_INSTALL_BASE/xyce_parallel"
    cmake \
    -D CMAKE_INSTALL_PREFIX=$XYCE_INSTALL_LOCATION \
    -D Trilinos_ROOT="/usr/local/trilinos_parallel" \
    -D CMAKE_CXX_FLAGS=$(XYCE_CXX_FLAGS) \
    -D CMAKE_C_FLAGS=$(XYCE_C_FLAGS) \
    -D Xyce_PLUGIN_SUPPORT=ON \
    -D CMAKE_BUILD_TYPE=$XYCE_BUILD_TYPE \
    $XYCE_DEV_DIR/Xyce > xyce_parallel_build.log
else
    XYCE_INSTALL_LOCATION="$XYCE_INSTALL_BASE/xyce_serial"
    cmake \
    -D CMAKE_INSTALL_PREFIX=$XYCE_INSTALL_LOCATION \
    -D Trilinos_ROOT="/usr/local/trilinos_serial" \
    -D CMAKE_CXX_FLAGS=$(XYCE_CXX_FLAGS) \
    -D CMAKE_C_FLAGS=$(XYCE_C_FLAGS) \
    -D Xyce_PLUGIN_SUPPORT=ON \
    -D CMAKE_BUILD_TYPE=$XYCE_BUILD_TYPE \
    $XYCE_DEV_DIR/Xyce > xyce_serial_build.log
fi 
```

Under testing at the moment. Looks to be building ok. 